### PR TITLE
Migrate front-end to vite and dockerize for ec2

### DIFF
--- a/.github/workflows/restaurant-front-docker.yml
+++ b/.github/workflows/restaurant-front-docker.yml
@@ -1,0 +1,50 @@
+name: Build and Push Restaurant Front to ECR
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "restaurant_front/**"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  ECR_REPOSITORY: restaurant-front
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./restaurant_front
+          file: ./restaurant_front/Dockerfile
+          push: true
+          provenance: false
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/restaurant_front/.env.example
+++ b/restaurant_front/.env.example
@@ -1,0 +1,3 @@
+# Vite environment variables must be prefixed with VITE_
+VITE_API_URL=http://localhost:8080
+

--- a/restaurant_front/Dockerfile
+++ b/restaurant_front/Dockerfile
@@ -1,38 +1,17 @@
-# Multi-stage build for React frontend
+### Build stage
 FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
 
-# Set working directoryx
 WORKDIR /app
-
-# Copy package files
 COPY package*.json ./
-
-# Install dependencies
 RUN npm ci
-
-# Copy source code
 COPY . .
-
-# Build the application
 RUN npm run build
 
-# Final stage
-FROM --platform=linux/arm64 node:20-alpine
+### Runtime stage (Nginx)
+FROM nginx:alpine
 
-# Set working directory
-WORKDIR /app
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Copy built files from builder stage
-COPY --from=builder /app/build /app/build
-
-# Copy package files
-COPY package*.json ./
-
-# Install dependencies
-RUN npm ci --only=production
-
-# Expose port 3000
-EXPOSE 3000
-
-# Start the application
-CMD ["npm", "run", "start"]
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/restaurant_front/README.md
+++ b/restaurant_front/README.md
@@ -1,27 +1,26 @@
-# Getting Started with Create React App
+# Getting Started with Vite
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project is built with [Vite](https://vitejs.dev/).
 
 ## Available Scripts
 
 In the project directory, you can run:
 
-### `npm start`
+### `npm run dev`
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Runs the app in development mode with Vite.\
+Open [http://localhost:5173](http://localhost:5173) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 
-### `npm test`
+### `npm run preview`
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Locally preview the production build on port 3000.
 
 ### `npm run build`
 
-Builds the app for production to the `build` folder.\
+Builds the app for production to the `dist` folder.\
 It correctly bundles React in production mode and optimizes the build for the best performance.
 
 The build is minified and the filenames include the hashes.\
@@ -29,18 +28,18 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
+### Environment
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+Vite uses `VITE_`-prefixed variables. Copy `.env.example` to `.env` and set `VITE_API_URL`.
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+### Docker
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+Production image is a multi-stage build that serves static files with Nginx.\
+Build: `docker build -t your/image:tag .`\
+Run: `docker run -p 8080:80 your/image:tag`
 
 ## Learn More
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+You can learn more in the [Vite documentation](https://vitejs.dev/guide/).
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+To learn React, check out the [React documentation](https://react.dev/).

--- a/restaurant_front/index.html
+++ b/restaurant_front/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Restaurant Frontend" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Restaurant Front</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+  
+</html>
+

--- a/restaurant_front/nginx.conf
+++ b/restaurant_front/nginx.conf
@@ -1,0 +1,19 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # Static assets caching (optional)
+  location ~* \.(?:css|js|svg|jpg|jpeg|png|gif|ico|woff2?)$ {
+    expires 7d;
+    access_log off;
+    add_header Cache-Control "public";
+  }
+}
+

--- a/restaurant_front/package.json
+++ b/restaurant_front/package.json
@@ -38,7 +38,6 @@
     "react-konva": "^19.0.3",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.1.5",
-    "react-scripts": "^5.0.1",
     "react-slick": "^0.30.3",
     "recharts": "^2.15.1",
     "slick-carousel": "^1.8.1",
@@ -48,10 +47,9 @@
     "zod": "^3.24.2"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 3000",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "clean": "eslint src --ext .ts,.tsx --fix"
   },
@@ -74,6 +72,8 @@
     ]
   },
   "devDependencies": {
+    "@vitejs/plugin-react-swc": "^3.7.2",
+    "vite": "^6.0.0",
     "@types/react-slick": "^0.23.13",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",

--- a/restaurant_front/public/index.html
+++ b/restaurant_front/public/index.html
@@ -2,27 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
+      This file is used only for static assets. Vite's root index.html lives at project root.
     -->
     <title>React App</title>
   </head>

--- a/restaurant_front/src/config/config.ts
+++ b/restaurant_front/src/config/config.ts
@@ -8,12 +8,15 @@ interface Config {
 }
 
 const getConfig = (): Config => {
-  const env = process.env.NODE_ENV || 'development';
-  const envConfig = environment[env as keyof typeof environment] || environment.development;
+  const envMode = (import.meta as any).env?.MODE || 'development';
+  const envKey = (envMode as keyof typeof environment) || 'development';
+  const envConfig = environment[envKey] || environment.development;
+
+  const apiUrlFromEnv = (import.meta as any).env?.VITE_API_URL as string | undefined;
 
   return {
     ...envConfig,
-    API_URL: envConfig.API_URL,
+    API_URL: apiUrlFromEnv ?? envConfig.API_URL,
     ENVIRONMENT: envConfig.ENVIRONMENT,
   };
 };

--- a/restaurant_front/src/pages/admin/IngredientPage.tsx
+++ b/restaurant_front/src/pages/admin/IngredientPage.tsx
@@ -18,6 +18,7 @@ import { toaster } from '../../components/ui/toaster';
 import { CustomField } from '../../components/ui/field';
 import { IngredientTable } from '../../components/ingredients/IngredientTable';
 import { deleteRawIngredient, updateRawIngredients } from '../../services/rawIngredientService';
+import config from '../../config/config';
 
 interface IngredientRow {
   raw_ingredient_id: string;
@@ -110,7 +111,7 @@ const IngredientPage: React.FC = () => {
       const formData = new FormData();
       formData.append('file', file);
       const response = await fetch(
-        `${process.env.REACT_APP_API_URL || 'http://localhost:8080'}/raw-ingredients/upload?restaurant_id=${restaurantId}`,
+        `${config.API_URL}/raw-ingredients/upload?restaurant_id=${restaurantId}`,
         {
           method: 'POST',
           body: formData,

--- a/restaurant_front/src/react-app-env.d.ts
+++ b/restaurant_front/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/restaurant_front/src/vite-env.d.ts
+++ b/restaurant_front/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+

--- a/restaurant_front/tsconfig.json
+++ b/restaurant_front/tsconfig.json
@@ -19,7 +19,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react-jsx"
   },
   "include": [
     "src"

--- a/restaurant_front/vite.config.ts
+++ b/restaurant_front/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+  preview: {
+    port: 3000,
+  },
+});
+


### PR DESCRIPTION
Migrate `restaurant_front` to Vite and add a production-ready Dockerfile with GitHub Actions for ECR deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-666c9ac6-9b56-4b44-8abd-475aad9c257b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-666c9ac6-9b56-4b44-8abd-475aad9c257b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

